### PR TITLE
Async calls using new SDK by OpenAI

### DIFF
--- a/mock_test.py
+++ b/mock_test.py
@@ -1,5 +1,7 @@
 import asyncio
+from dotenv import load_dotenv
 
+load_dotenv()
 from openai_multi_client import OpenAIMultiClient, Payload, OpenAIMultiOrderedClient
 
 
@@ -12,7 +14,7 @@ def test(ordered):
         rand_fail = random.random()
         if rand_fail < 0.3:
             raise Exception("Mocked exception")
-        return {"response": f"mocked {payload.metadata['id']}"}
+        return {"response": f"mocked {payload.metadata.get('id')}"}
 
     if ordered:
         api = OpenAIMultiOrderedClient(custom_api=mock, max_retries=3, retry_multiplier=2)
@@ -35,9 +37,10 @@ def test(ordered):
         i += 1
         if response.failed:
             failed += 1
-            print(f"Failed {response.metadata['id']}: {i}/100")
+            print(f"Failed {response.metadata.get('id')}: {i}/100")
         else:
-            print(f"Got response {response.metadata['id']}: {i}/100")
+            print(f"Got response {response.metadata.get('id')}: {i}/100")
+
 
     print('*' * 20)
     print(f"Total failed: {failed}/100")

--- a/mock_test.py
+++ b/mock_test.py
@@ -1,7 +1,4 @@
 import asyncio
-from dotenv import load_dotenv
-
-load_dotenv()
 from openai_multi_client import OpenAIMultiClient, Payload, OpenAIMultiOrderedClient
 
 

--- a/openai_multi_client/__init__.py
+++ b/openai_multi_client/__init__.py
@@ -6,7 +6,9 @@ from typing import Any, Optional
 
 from aioprocessing import AioJoinableQueue, AioQueue
 from tenacity import wait_random_exponential, stop_after_attempt, AsyncRetrying, RetryError
-import openai
+from openai import AsyncOpenAI
+
+aclient = AsyncOpenAI()
 
 logger = logging.getLogger(__name__)
 
@@ -76,17 +78,17 @@ class OpenAIMultiClient:
         if self._mock_api:
             payload.response = await self._mock_api(payload)
         elif payload.endpoint == "completions":
-            payload.response = await openai.Completion.acreate(**payload.data)
+            payload.response = await aclient.completions.create(**payload.data)
         elif payload.endpoint == "chat.completions" or payload.endpoint == "chats":
-            payload.response = await openai.ChatCompletion.acreate(**payload.data)
+            payload.response = await aclient.chat.completions.create(**payload.data)
         elif payload.endpoint == "embeddings":
-            payload.response = await openai.Embedding.acreate(**payload.data)
+            payload.response = await aclient.embeddings.create(**payload.data)
         elif payload.endpoint == "edits":
-            payload.response = await openai.Edit.acreate(**payload.data)
+            payload.response = await aclient.edits.create(**payload.data)
         elif payload.endpoint == "images":
-            payload.response = await openai.Image.acreate(**payload.data)
+            payload.response = await aclient.images.generate(**payload.data)
         elif payload.endpoint == "fine-tunes":
-            payload.response = await openai.FineTune.acreate(**payload.data)
+            payload.response = await aclient.fine_tunes.create(**payload.data)
         else:
             raise ValueError(f"Unknown endpoint {payload.endpoint}")
         logger.debug(f"Processed {payload}")

--- a/real_test.py
+++ b/real_test.py
@@ -1,7 +1,4 @@
 import os
-from dotenv import load_dotenv
-
-load_dotenv()
 from openai_multi_client import OpenAIMultiClient, Payload
 
 

--- a/real_test.py
+++ b/real_test.py
@@ -1,4 +1,7 @@
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 from openai_multi_client import OpenAIMultiClient, Payload
 
 
@@ -37,7 +40,7 @@ def on_success(result: Payload):
         print(f"Failed {pid}")
     else:
         print(f"Got response for {pid}:",
-              result.response['choices'][0]['message']['content'])
+              result.response.choices[0].message.content)
 
 
 def test_callback():


### PR DESCRIPTION
**Issue / Bug**
Current implementation of OpenAIMultiClient is according to older version of OpenAI.
For async calls `acreate` function was used to do asynchronous calls.
Example from OpenAI repo:
```python
import openai

completion = openai.ChatCompletion.acreate(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
``` 

When executing this MultiClient it says to migrate the code accordingly, and gives a lot of errors.
Either we can fix this by explicitly downloading earlier version of openai which is `openai==0.28` or the migration I have done.

**Fix**

OpenAI has introduced AsyncOpenAI class through which we can handle this case
Example from OpenAI repo:
```python
from openai import AsyncOpenAI

client = AsyncOpenAI()
completion = await client.chat.completions.create(model="gpt-3.5-turbo", messages=[{"role": "user", "content": "Hello world"}])
``` 
Calls are relatively different from previous SDK. New SDK has a lot of changes. 